### PR TITLE
Fixes after user feedbacks

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -10,6 +10,7 @@ pub enum AcType {
     SendMsg = 3,
     Invoke = 4,
     Print = 5,
+    Goto = 6,
     CallEngine = 10,
     Unknown = 255,
 }
@@ -23,6 +24,7 @@ impl From<u8> for AcType {
             3 => AcType::SendMsg,
             4 => AcType::Invoke,
             5 => AcType::Print,
+            6 => AcType::Goto,
             10 => AcType::CallEngine,
             _ => AcType::Unknown,
         }
@@ -40,8 +42,6 @@ pub struct DAction {
     pub action_type: AcType,
     #[serde(deserialize_with = "from_0x_hex")]
     pub to: u8,
-    #[serde(deserialize_with = "from_0x_hex")]
-    pub id: u8,
     #[serde(deserialize_with = "from_hex_to_utf8_str")]
     pub attrs: String,
     pub misc: String,
@@ -55,20 +55,18 @@ impl DAction {
             name: String::new(),
             action_type: AcType::Empty,
             to: 0,
-            id: 0,
             attrs: String::new(),
             misc: String::new(),
         }
     }
     
     #[allow(dead_code)]
-    pub fn new(desc: String, name: String, action_type: u8, to: u8, id: u8) -> Self {
+    pub fn new(desc: String, name: String, action_type: u8, to: u8) -> Self {
         DAction {
             desc,
             name,
             action_type: action_type.into(),
             to,
-            id,
             attrs: String::new(),
             misc: String::new(),
         }

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,4 +1,3 @@
-use super::context::DContext;
 use super::action::DAction;
 use ton_client_rs::{Ed25519KeyPair, TonAddress};
 
@@ -6,7 +5,9 @@ pub trait BrowserCallbacks {
     /// Debot sends text message to user.
     fn log(&self, msg: String);
     /// Debot is switched to another context.
-    fn switch(&self, ctx: &DContext);
+    fn switch(&self, ctx_id: u8);
+    // Dengine calls this callback after `switch` callback for every action in context
+    fn show_action(&self, act: DAction);
     // Debot engine asks user to enter argument for an action. 
     fn input(&self, prefix: &str, value: &mut String);
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,17 +4,19 @@ use std::fmt::Display;
 use std::str::FromStr;
 
 pub const STATE_ZERO: u8 = 0;
-pub const STATE_EXIT: u8 = 255; 	// get out
+pub const STATE_CURRENT: u8 = 253;
+pub const STATE_PREV: u8 = 254; 	
+pub const STATE_EXIT: u8 = 255;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone)]
 pub struct DContext {
+    #[serde(deserialize_with = "from_0x_hex")]
+    pub id: u8,
     #[serde(deserialize_with = "from_hex_to_utf8_str")]
     pub desc: String,
     pub actions: Vec<DAction>,
-    #[serde(deserialize_with = "from_0x_hex")]
-    pub id: u8
 }
 
 impl DContext {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,10 @@ mod tests {
         fn load_key(&self, _keys: &mut Ed25519KeyPair) {
             println!("load_key");
         }
+        fn invoke_debot(&self, _debot: TonAddress, _action: DAction) -> Result<(), String> {
+            println!("invoke_debot");
+            Ok(())
+        }
 
     }
 

--- a/src/routines.rs
+++ b/src/routines.rs
@@ -1,6 +1,15 @@
 use chrono::{TimeZone, Local};
 use ton_client_rs::TonClient;
 
+pub fn call_routine(ton: &TonClient, name: &str, arg: &str) -> Result<String, String> {
+    match name {
+        "convertTokens" => convert_string_to_tokens(&ton, arg),
+        "getBalance" => get_balance(&ton, arg),
+        "loadBocFromFile" => load_boc_from_file(&ton, arg),
+        _ => Err(format!("unknown engine routine: {}", name))?,
+    }
+}
+
 pub fn convert_string_to_tokens(_ton: &TonClient, arg: &str) -> Result<String, String> {
     let parts: Vec<&str> = arg.split(".").collect();
     if parts.len() >= 1 && parts.len() <= 2 {


### PR DESCRIPTION
- Removed unused action.id field
- Supported new action (action_move_to)
- Supported predefined
- Fixed order of action execution: context actions are executed exactly in order in which they are defined in context (independently from "instant" attribute)
- added new callback into browser interface: show_action.
