### PR TITLE
Fix sign_hash routine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_derive = "1.0.91"
 log = "0.4.11"
+num-bigint = "0.3"
+num-traits = "0.2.12"
 
 ton-client-rs = { git = 'https://github.com/tonlabs/ton-client-rs.git', tag = "0.26.0" }
 ton_sdk = { git = 'https://github.com/tonlabs/TON-SDK.git', tag = "0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "Apache-2.0"
 keywords = ["DeBot", "TON", "debot engine"]
 edition = "2018"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 base64 = "0.10.1"

--- a/src/routines.rs
+++ b/src/routines.rs
@@ -105,15 +105,66 @@ pub(super) fn load_boc_from_file(_ton: &TonClient, arg: &str) -> Result<String, 
 
 }
 
-pub(super) fn sign_hash(arg: &str, keypair: Ed25519KeyPair) -> Result<String, String> {
-    debug!("sign hash {}", arg);
+fn extract_hash(arg: &str) -> Result<Vec<u8>, String> {
     let arg_json: serde_json::Value = serde_json::from_str(arg)
         .map_err(|e| format!("argument is invalid json: {}", e))?;
     let hash_str = arg_json["hash"].as_str()
         .ok_or(format!(r#""hash" argument not found"#))?;
     let hash_str = hash_str.get(2..).ok_or("hash is not an uint256 number".to_owned())?;
-    let hash_vec = hex::decode(hash_str).unwrap();
+    hex::decode(&format!("{:0>64}", hash_str))
+        .map_err(|e| {
+            format!("failed to decode hash from hex string:\n hash: {}\n error: {}", hash_str, e)
+        })
+}
+
+pub(super) fn sign_hash(arg: &str, keypair: Ed25519KeyPair) -> Result<String, String> {
+    debug!("sign hash {}", arg);
+    let hash_vec = extract_hash(arg)?;
     let keypair = Keypair::from_bytes(&keypair.to_bytes()).unwrap();
     let signature: Signature = keypair.sign(&hash_vec);
     Ok(hex::encode(&signature.to_bytes()[..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex;
+
+    fn get_keypair() -> Ed25519KeyPair {
+        let keys_str = r#"{
+            "public": "9711a04f0b19474272bc7bae5472a8fbbb6ef71ce9c193f5ec3f5af808069a41",
+            "secret": "cdf2a820517fa783b9b6094d15e650af92d485084ab217fc2c859f02d49623f3"
+        }"#;
+        serde_json::from_str(&keys_str).unwrap()
+    }
+
+    #[test]
+    fn test_sign_hash_1() {
+        let hash = "0x432461b752243bba76ad56fe14f88d2d0bb224c68f1c598dd3a34ee3204ddc84";
+        let arg = json!({ "hash": hash }).to_string();
+        sign_hash(&arg, get_keypair()).unwrap();
+    }
+
+    #[test]
+    fn test_sign_hash_2() {
+        let hash2 = "0x32461b752243bba76ad56fe14f88d2d0bb224c68f1c598dd3a34ee3204ddc84";
+        let arg = json!({ "hash": hash2 }).to_string();
+        sign_hash(&arg, get_keypair()).unwrap();
+    }
+
+    #[test]
+    fn test_extract_hash_1() {
+        let hash2 = "0x32461b752243bba76ad56fe14f88d2d0bb224c68f1c598dd3a34ee3204ddc84";
+        let arg = json!({ "hash": hash2 }).to_string();
+        let valid_hash = hex::decode("032461b752243bba76ad56fe14f88d2d0bb224c68f1c598dd3a34ee3204ddc84").unwrap();
+        assert_eq!(valid_hash, extract_hash(&arg).unwrap());
+    }
+
+    #[test]
+    fn test_extract_hash_2() {
+        let hash3 = "0x2461b752243bba76ad56fe14f88d2d0bb224c68f1c598dd3a34ee3204ddc80";
+        let valid_hash = hex::decode("002461b752243bba76ad56fe14f88d2d0bb224c68f1c598dd3a34ee3204ddc80").unwrap();
+        let arg = json!({ "hash": hash3 }).to_string();
+        assert_eq!(valid_hash, extract_hash(&arg).unwrap());
+    }
 }


### PR DESCRIPTION
Leading zeroes are added to hex string to correctly decode hash to byte array. 