### PR TITLE
Fix return from invoke

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "Apache-2.0"
 keywords = ["DeBot", "TON", "debot engine"]
 edition = "2018"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 base64 = "0.10.1"


### PR DESCRIPTION
When invoked debot shut down, force dengine to reswitch to current context to print all context actions again.